### PR TITLE
Update citation (Solar Energy paper)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Jensen"
+  given-names: "Adam R."
+  orcid: "https://orcid.org/0000-0002-5554-9856"
+- family-names: "Anderson"
+  given-names: "Kevin"
+  orcid: "https://orcid.org/0000-0002-1166-7957"
+title: "twoaxistracking"
+url: "https://github.com/pvlib/twoaxistracking"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Jensen"
+    given-names: "Adam R."
+    orcid: "https://orcid.org/0000-0002-5554-9856"
+  - family-names: "Sifnaios"
+    given-names: "Ioannis"
+    orcid: "https://orcid.org/0000-0003-0933-2952"
+  - family-names: "Furbo"
+    given-names: "Simon"
+    orcid: "https://orcid.org/0000-0003-2578-4780"
+  - family-names: "Dragsted"
+    given-names: "Janne"
+    orcid: "https://orcid.org/0000-0002-6344-8326"
+  doi: "10.1016/j.solener.2022.02.023"
+  journal: "Solar Energy"
+  month: 9
+  start: 215 # First page number
+  end: 224 # Last page number
+  title: "Self-shading of two-axis tracking solar collectors: Impact of field layout, latitude, and aperture shape"
+  volume: 236
+  year: 2022

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The package can be installed using pip:
 
 ## Citing
 If you use the package in published work, please cite:
-> Adam R. Jensen, Ioannis Sifnaios, Janne Dragsted, and Simon Furbo. "Self­shading of two­axis
+> Adam R. Jensen, Ioannis Sifnaios, Simon Furbo, and Janne Dragsted. "Self-shading of two-axis
 > tracking solar collectors: Impact of field layout, latitude, and aperture shape." Solar
 > Energy, 236, 215–224, (2022). [https://doi.org/10.1016/j.solener.2022.02.023](https://doi.org/10.1016/j.solener.2022.02.023)
 

--- a/README.md
+++ b/README.md
@@ -9,19 +9,11 @@ The package can be installed using pip:
 
     pip install twoaxistracking
 
-The main non-standard dependency is `shapely`, which handles the geometric operations. It is recommended to install `shapely` using conda, which can be done by executing the following command in an Anaconda Prompt:
-
-    conda install shapely
-
-The solar modeling library `pvlib` is recommended for calculating the solar position and can be installed by the command:
-
-    pip install pvlib
-
 ## Citing
 If you use the package in published work, please cite:
-> Adam R. Jensen et al. 2022.
-> "Self-shading of two-axis tracking solar collectors: Impact of field layout, latitude, and aperture shape."
-> Accepted in Solar Energy.
+> Adam R. Jensen, Ioannis Sifnaios, Janne Dragsted, and Simon Furbo. "Self­shading of two­axis
+> tracking solar collectors: Impact of field layout, latitude, and aperture shape." Solar
+> Energy, 236, 215–224, (2022). [https://doi.org/10.1016/j.solener.2022.02.023](https://doi.org/10.1016/j.solener.2022.02.023)
 
 ## Contributing
 Contributions to the repository, e.g., bug fixes and improvements to speed up the code are more than welcome.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,9 +17,9 @@ Contributions to the repository, e.g., bug fixes, feature request are more than 
 
 ## Citing
 If you use the package in published work, please cite:
-> Adam R. Jensen et al. 2022.
-> "Self-shading of two-axis tracking solar collectors: Impact of field layout, latitude, and aperture shape."
-> Solar Energy (2022). [https://doi.org/10.1016/j.solener.2022.02.023](https://doi.org/10.1016/j.solener.2022.02.023)
+> Adam R. Jensen, Ioannis Sifnaios, Janne Dragsted, and Simon Furbo. "Self-shading of two-axis
+> tracking solar collectors: Impact of field layout, latitude, and aperture shape." Solar
+> Energy, 236, 215–224, (2022). [https://doi.org/10.1016/j.solener.2022.02.023](https://doi.org/10.1016/j.solener.2022.02.023)
 
 
 ```{toctree}

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,7 +17,7 @@ Contributions to the repository, e.g., bug fixes, feature request are more than 
 
 ## Citing
 If you use the package in published work, please cite:
-> Adam R. Jensen, Ioannis Sifnaios, Janne Dragsted, and Simon Furbo. "Self-shading of two-axis
+> Adam R. Jensen, Ioannis Sifnaios, Simon Furbo, and Janne Dragsted. "Self-shading of two-axis
 > tracking solar collectors: Impact of field layout, latitude, and aperture shape." Solar
 > Energy, 236, 215–224, (2022). [https://doi.org/10.1016/j.solener.2022.02.023](https://doi.org/10.1016/j.solener.2022.02.023)
 


### PR DESCRIPTION
The paper describing version 0.1 of this package has officially been published. This PR serves to update the citation.

> Adam R. Jensen, Ioannis Sifnaios, Janne Dragsted, and Simon Furbo. "Self-shading of two-axis
> tracking solar collectors: Impact of field layout, latitude, and aperture shape." Solar
> Energy, 236, 215–224, (2022). [https://doi.org/10.1016/j.solener.2022.02.023](https://doi.org/10.1016/j.solener.2022.02.023)
