### PR TITLE
Release version 0.2.1 and fix PyPI upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools wheel
+        python -m pip install --upgrade setuptools wheel build
     - name: Build packages
-      run: python setup.py sdist bdist_wheel
+      run: python -m build --sdist --wheel
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 __pycache__/
 
 # Distribution / packaging
-*/build/
+build/
+dist/
 *.egg-info/
 
 # generated documentation

--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2022-03-12
-Add pandas as required dependency and fix the workflow file responsible for uploading
-the pacakge to PyPI.
+## [0.2.1] - 2022-03-11
+Add pandas as a required dependency and fix the workflow file responsible for
+uploading the pacakge to PyPI.
 
-### Added
+### Requirements
 - Added pandas to the list of required dependencies
 
 

--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2022-03-12
+Add pandas as required dependency and fix the workflow file responsible for uploading
+the pacakge to PyPI.
+
+### Added
+- Added pandas to the list of required dependencies
+
+
 ## [0.2.0] - 2022-03-11
 The code in the second release is a complete restructure in order for the code to be 
 made into a package and available on PyPI.

--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.1] - 2022-03-11
 Add pandas as a required dependency and fix the workflow file responsible for
-uploading the pacakge to PyPI.
+uploading the package to PyPI.
 
 ### Requirements
 - Added pandas to the list of required dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = twoaxistracking
-version = 0.2.0
+version = 0.2.1
 author = 'Adam R. Jensen, Kevin Anderson'
 author_email = adam-r-j@hotmail.com
 description = twoaxistracking is a python package for simulating two-axis tracking solar collectors, particularly self-shading.

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,12 +24,12 @@ install_requires =
     numpy
     matplotlib
     shapely
+    pandas
 
 [options.extras_require]
 test =
     pytest
     pytest-cov
-    pandas
 doc =
     sphinx==4.4.0
     myst-nb==0.13.2


### PR DESCRIPTION
The publish.yml workflow was originally copied from pvlib-python which uses a setup.py file for the packaging process. However, this package uses the recommended setup.cfg file, thus the upload to Github Action upload to PyPI in #24 failed. Instead, the package was uploaded manually to PyPI.

Furthermore, pandas is used in the `trackerfield.py` file but was not on the list of required packages, thus in a clean environment, version 0.2.0 will fail. The current PR adds pandas to the list of required files.