### PR TITLE
Correct nan handling in max_shading_elevation

### DIFF
--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -12,7 +12,7 @@ An important bug fix and enhancement of the documentation.
 - Fix bug in the calculation of the maximum shading elevation at high GCRs (see PR#28).
 
 ### Added
-- Button on the documentation website liking to GitHub (see PR#27).
+- Button on the documentation website linking to GitHub (see PR#27).
 
 
 ## [0.2.1] - 2022-03-11

--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.2]
+An important bug fix and enhancement of the documentation.
+
+### Changed
+- Fix bug in the calculation of the maximum shading elevation at high GCRs (see PR#28).
+
+### Added
+- Button on the documentation website liking to GitHub (see PR#27).
+
+
 ## [0.2.1] - 2022-03-11
 Add pandas as a required dependency and fix the workflow file responsible for
 uploading the package to PyPI.

--- a/twoaxistracking/layout.py
+++ b/twoaxistracking/layout.py
@@ -182,5 +182,6 @@ def max_shading_elevation(total_collector_geometry, tracker_distance,
     # Compute max elevation (if both contain nan, then set max_elevation to 90)
     max_elevation = np.min(
         [np.nan_to_num(max_elevations_rectangular, nan=90).max(),
-          np.nan_to_num(max_elevations_circular, nan=90).max()])
+         np.nan_to_num(max_elevations_circular, nan=90).max()])
+
     return max_elevation

--- a/twoaxistracking/layout.py
+++ b/twoaxistracking/layout.py
@@ -166,7 +166,7 @@ def max_shading_elevation(total_collector_geometry, tracker_distance,
     """
     # Calculate extent of box bounding the total collector geometry
     x_min, y_min, x_max, y_max = total_collector_geometry.bounds
-    # Collector dimensions
+    # Collector rectangular bounding box dimensions
     x_dim = x_max - x_min
     y_dim = y_max - y_min
     delta_gamma_rad = np.arcsin(x_dim / tracker_distance)
@@ -179,7 +179,8 @@ def max_shading_elevation(total_collector_geometry, tracker_distance,
     max_elevations_circular = np.rad2deg(np.arcsin(
         (D_min * np.cos(np.deg2rad(relative_slope)))/tracker_distance)) \
         + relative_slope
-    # Compute max elevation
-    max_elevation = np.nanmin([np.nanmax(max_elevations_rectangular),
-                               np.nanmax(max_elevations_circular)])
+    # Compute max elevation (if both contain nan, then set max_elevation to 90)
+    max_elevation = np.min(
+        [np.nan_to_num(max_elevations_rectangular, nan=90).max(),
+          np.nan_to_num(max_elevations_circular, nan=90).max()])
     return max_elevation

--- a/twoaxistracking/tests/test_layout.py
+++ b/twoaxistracking/tests/test_layout.py
@@ -174,4 +174,4 @@ def test_calculation_of_max_shading_elevation_circle(circular_geometry):
 
     max_shading_elevation = layout.max_shading_elevation(
         collector_geometry, tracker_distance, relative_slope)
-    np.testing.assert_allclose(max_shading_elevation, 43.16784217)
+    np.testing.assert_allclose(max_shading_elevation, 52.989564)


### PR DESCRIPTION
This PR fixes a bug in the way the `max_shading_elevation` function handles nan values, which can occur for very high ground coverage ratios (which is why it was able to go undetected).

The function essentially calculates the maximum shading elevation for each neighboring collector assuming the worst possible azimuth alignment. It does this calculation for both a circular and rectangular bounding box around the gross collector area. The result is then two arrays of the maximum shading elevation calculated for each neighboring collector. If the GCR is very high. Either the array of maximum shading elevation for the rectangular or circular case may yield nan values. The code previously ignored these nan values, which was incorrect, instead they should be set to 90 degrees. The final step of the calculation procedure is to take the maximum value of each array of values for the rectangular and circular cases. The actual maximum shading elevation can then be computed as the minimum of these two values. The concept may better be explained by the code below.

Original code (buggy):

    max_elevation = np.nanmin([np.nanmax(max_elevations_rectangular),
                               np.nanmax(max_elevations_circular)])

New code (correct):

    max_elevation = np.min(
        [np.nan_to_num(max_elevations_rectangular, nan=90).max(),
         np.nan_to_num(max_elevations_circular, nan=90).max()])

I found this mistake when I was running some simulations and got different results when I used the maximum shaded elevation calculated by `max_shading_elevation` vs. setting it to 90 degrees. Specifying the max shaded elevation should NOT have any impact on the shading results (that is if it is specified correctly); its only function is to skip simulations that do not have any shading.

When I corrected the nan handling in the `max_shading_elevation` function, it resulted in one test failure. I, therefore, calculated the maximum shading elevation by brute force for the specific test case and found that it was incorrectly set - so the test failure was a sign that the bug fix actually works.