### PR TITLE
Add return_geometries parameter to shaded_fraction

### DIFF
--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+- Added ``return_geometries`` argument to the {py:func}`twoaxistracking.shaded_fraction`.
+  When the argument is True, the function returns both the shaded fraction and a dictionary
+  with the geometries of the unshaded area and the shading areas (see PR#33).
+
 
 ## [0.2.2] - 2022-09-14
 This update includes a bug fix in the calculation of the maximum shading elevation
@@ -47,7 +52,6 @@ made into a package and available on PyPI.
 - Added {py:func}`twoaxistracking.shading.horizon_elevation_angle` for calculating the
   horizon angle caused by having a sloped field.
 
-
 ### Changed
 - Divide code into modules: shading, plotting, and layout
 - Changed the overall file structure to become a Python package
@@ -63,6 +67,7 @@ made into a package and available on PyPI.
 ### Testing
 - Linting using flake8 was added in PR#11
 - Test coverage was added in PR#14 and PR#16
+
 
 ## [0.1.0] - 2022-01-25
 This was the first release, containing the main functions and notebooks.

--- a/twoaxistracking/plotting.py
+++ b/twoaxistracking/plotting.py
@@ -44,6 +44,9 @@ def _polygons_to_patch_collection(geometries, **kwargs):
     """
     # Convert geometries to a list
     if isinstance(geometries, geometry.Polygon):
+        # If polygon has area of zero, make path collection empty
+        if geometries.area == 0:
+            return collections.PatchCollection([], **kwargs)
         geometries = [geometries]
     elif isinstance(geometries, geometry.MultiPolygon):
         geometries = list(geometries.geoms)

--- a/twoaxistracking/shading.py
+++ b/twoaxistracking/shading.py
@@ -90,7 +90,7 @@ def shaded_fraction(solar_elevation, solar_azimuth,
         if return_geometries:
             # Both geometries are set as empty
             return shaded_fraction, {'unshaded_geometry': geometry.Polygon(),
-                                     'shading_geometries': geometry.Polygon()}
+                                     'shading_geometries': []}
         else:
             return shaded_fraction
 
@@ -102,7 +102,7 @@ def shaded_fraction(solar_elevation, solar_azimuth,
             # Unshaded area is equal to the active area, shading geometries
             # is set as empty as there is no intersection with the active area
             return shaded_fraction, {'unshaded_geometry': active_collector_geometry,
-                                     'shading_geometries': geometry.Polygon()}
+                                     'shading_geometries': []}
         else:
             return shaded_fraction
 
@@ -113,7 +113,7 @@ def shaded_fraction(solar_elevation, solar_azimuth,
         if return_geometries:
             # Both geometries are set as empty
             return shaded_fraction, {'unshaded_geometry': geometry.Polygon(),
-                                     'shading_geometries': geometry.Polygon()}
+                                     'shading_geometries': []}
         else:
             return shaded_fraction
 

--- a/twoaxistracking/shading.py
+++ b/twoaxistracking/shading.py
@@ -82,7 +82,12 @@ def shaded_fraction(solar_elevation, solar_azimuth,
         Shaded fraction for the specific solar position and field layout.
     geometries: dict
         A dictionary with the keys {'unshaded_geometry', 'shading_geometries'}.
-        Only returned if ``return_geometries`` is True.
+        ``unshaded_geometry`` is a shapely Polygon or MultiPolygon representing
+        the unshaded subset of ``active_collector_geometry``.
+        ``shading_geometries`` is a list of shapely Polygons representing the
+        ``total_collector_geometries`` of neighboring collectors within the
+        shaded collector's field of view. Only returned if
+        ``return_geometries`` is True.
     """
     # If the sun is below the horizon, set the shaded fraction to nan
     if solar_elevation < 0:

--- a/twoaxistracking/tests/conftest.py
+++ b/twoaxistracking/tests/conftest.py
@@ -7,28 +7,26 @@ from twoaxistracking import layout
 @pytest.fixture
 def rectangular_geometry():
     collector_geometry = geometry.box(-2, -1, 2, 1)
-    total_collector_area = collector_geometry.area
     min_tracker_spacing = layout._calculate_min_tracker_spacing(collector_geometry)
-    return collector_geometry, total_collector_area, min_tracker_spacing
+    return collector_geometry, min_tracker_spacing
 
 
 @pytest.fixture
 def circular_geometry():
     # A circular collector centered at (0,0) and has a radius of 2
     collector_geometry = geometry.Point(0, 0).buffer(2)
-    total_collector_area = collector_geometry.area
     min_tracker_spacing = layout._calculate_min_tracker_spacing(collector_geometry)
-    return collector_geometry, total_collector_area, min_tracker_spacing
+    return collector_geometry, min_tracker_spacing
 
 
 @pytest.fixture
 def active_geometry_split():
-    active_collector_geometry = geometry.MultiPolygon([
+    active_geometry_split = geometry.MultiPolygon([
         geometry.box(-1.9, -0.9, -0.1, -0.1),
         geometry.box(0.1, -0.9, 1.9, -0.1),
         geometry.box(-1.9, 0.1, -0.1, 0.9),
         geometry.box(0.1, 0.1, 1.9, 0.9)])
-    return active_collector_geometry
+    return active_geometry_split
 
 
 @pytest.fixture

--- a/twoaxistracking/tests/test_layout.py
+++ b/twoaxistracking/tests/test_layout.py
@@ -34,14 +34,14 @@ def test_min_tracker_spacingpolygon():
 
 def test_square_layout_generation(rectangular_geometry, square_field_layout):
     # Test that a square field layout is returned correctly
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X_exp, Y_exp, Z_exp, tracker_distance_exp, relative_azimuth_exp, relative_slope_exp = \
         square_field_layout
 
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         layout.generate_field_layout(
             gcr=0.125,
-            total_collector_area=total_collector_area,
+            total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing,
             neighbor_order=1,
             aspect_ratio=1,
@@ -57,13 +57,13 @@ def test_square_layout_generation(rectangular_geometry, square_field_layout):
 
 def test_field_slope(rectangular_geometry, square_field_layout_sloped):
     # Test that a square field layout on tilted surface is returned correctly
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X_exp, Y_exp, Z_exp, tracker_distance_exp, relative_azimuth_exp, relative_slope_exp = \
         square_field_layout_sloped
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         layout.generate_field_layout(
             gcr=0.125,
-            total_collector_area=total_collector_area,
+            total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing,
             neighbor_order=1,
             aspect_ratio=1,
@@ -81,64 +81,64 @@ def test_field_slope(rectangular_geometry, square_field_layout_sloped):
 
 def test_layout_generation_value_error(rectangular_geometry):
     # Test if value errors are correctly raised
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
 
     # Test if ValueError is raised if offset is out of range
     with pytest.raises(ValueError, match="offset is outside the valid range"):
         _ = layout.generate_field_layout(
-            gcr=0.25, total_collector_area=total_collector_area,
+            gcr=0.25, total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing, neighbor_order=1,
             aspect_ratio=1, offset=1.1, rotation=0)
 
     # Test if ValueError is raised if aspect ratio is too low
     with pytest.raises(ValueError, match="Aspect ratio is too low"):
         _ = layout.generate_field_layout(
-            gcr=0.25, total_collector_area=total_collector_area,
+            gcr=0.25, total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing, neighbor_order=1,
             aspect_ratio=0.6, offset=0, rotation=0)
 
     # Test if ValueError is raised if aspect ratio is too high
     with pytest.raises(ValueError, match="Aspect ratio is too high"):
         _ = layout.generate_field_layout(
-            gcr=0.25, total_collector_area=total_collector_area,
+            gcr=0.25, total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing, neighbor_order=1,
             aspect_ratio=5, offset=0, rotation=0)
 
     # Test if ValueError is raised if rotation is greater than 180 degrees
     with pytest.raises(ValueError, match="rotation is outside the valid range"):
         _ = layout.generate_field_layout(
-            gcr=0.25, total_collector_area=total_collector_area,
+            gcr=0.25, total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing, neighbor_order=1,
             aspect_ratio=1.2, offset=0, rotation=190)
 
     # Test if ValueError is raised if rotation is less than 0
     with pytest.raises(ValueError, match="rotation is outside the valid range"):
         _ = layout.generate_field_layout(
-            gcr=0.5, total_collector_area=total_collector_area,
+            gcr=0.5, total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing, neighbor_order=1,
             aspect_ratio=1, offset=0, rotation=-1)
 
     # Test if ValueError is raised if min_tracker_spacing is outside valid range
     with pytest.raises(ValueError, match="Lmin is not physically possible"):
         _ = layout.generate_field_layout(
-            gcr=0.25, total_collector_area=total_collector_area,
+            gcr=0.25, total_collector_area=collector_geometry.area,
             min_tracker_spacing=1, neighbor_order=1, aspect_ratio=1.2,
             offset=0, rotation=90)
 
     # Test if ValueError is raised if maximum ground cover ratio is exceeded
     with pytest.raises(ValueError, match="Maximum ground cover ratio exceded"):
         _ = layout.generate_field_layout(
-            gcr=0.5, total_collector_area=total_collector_area,
+            gcr=0.5, total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing, neighbor_order=1,
             aspect_ratio=1, offset=0, rotation=0)
 
 
 def test_neighbor_order(rectangular_geometry):
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         layout.generate_field_layout(
             gcr=0.125,
-            total_collector_area=total_collector_area,
+            total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing,
             neighbor_order=3,
             aspect_ratio=1,
@@ -150,7 +150,7 @@ def test_neighbor_order(rectangular_geometry):
 def test_calculation_of_max_shading_elevation_rectangle(rectangular_geometry, square_field_layout):
     # Test that the maximum elevation angle for which shading can occur is
     # calculated correctly for rectangular collectors
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         square_field_layout
     max_shading_elevation = layout.max_shading_elevation(
@@ -161,11 +161,11 @@ def test_calculation_of_max_shading_elevation_rectangle(rectangular_geometry, sq
 def test_calculation_of_max_shading_elevation_circle(circular_geometry):
     # Test that the maximum elevation angle for which shading can occur is
     # calculated correctly for closely packed circular collectors
-    collector_geometry, total_collector_area, min_tracker_spacing = circular_geometry
+    collector_geometry, min_tracker_spacing = circular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         layout.generate_field_layout(
             gcr=0.5,
-            total_collector_area=total_collector_area,
+            total_collector_area=collector_geometry.area,
             min_tracker_spacing=min_tracker_spacing,
             neighbor_order=2,
             aspect_ratio=1,

--- a/twoaxistracking/tests/test_plotting.py
+++ b/twoaxistracking/tests/test_plotting.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from twoaxistracking import plotting, trackerfield
 from .conftest import assert_isinstance
 import numpy as np
+from shapely import geometry
 
 
 def test_field_layout_plot():
@@ -15,7 +16,7 @@ def test_field_layout_plot():
 
 
 def test_shading_plot(rectangular_geometry, active_geometry_split):
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     result = plotting._plot_shading(
         active_geometry_split,
         collector_geometry,
@@ -25,9 +26,22 @@ def test_shading_plot(rectangular_geometry, active_geometry_split):
     plt.close('all')
 
 
+def test_shading_plot_empty_active_area(rectangular_geometry, active_geometry_split):
+    # This test serves to test the correct operation of the
+    # _polygons_to_patch_collection function when the area of the Polygon is 0
+    collector_geometry, min_tracker_spacing = rectangular_geometry
+    result = plotting._plot_shading(
+        geometry.Polygon(),
+        collector_geometry,
+        collector_geometry,
+        min_tracker_spacing)
+    assert_isinstance(result, plt.Figure)
+    plt.close('all')
+
+
 def test_plotting_of_field_layout(rectangular_geometry):
     # Test if plot_field_layout returns a figure object
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,

--- a/twoaxistracking/tests/test_shading.py
+++ b/twoaxistracking/tests/test_shading.py
@@ -1,11 +1,13 @@
 from twoaxistracking import shading
 import numpy as np
+from shapely import geometry
+import shapely
 
 
 def test_shading(rectangular_geometry, active_geometry_split, square_field_layout):
     # Test shading calculation
     # Also plots the geometry (ensures no errors are raised)
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         square_field_layout
     shaded_fraction = shading.shaded_fraction(
@@ -25,7 +27,7 @@ def test_shading(rectangular_geometry, active_geometry_split, square_field_layou
 
 def test_shading_zero_solar_elevation(rectangular_geometry, square_field_layout):
     # Test shading when geometries completely overlap
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         square_field_layout
     shaded_fraction = shading.shaded_fraction(
@@ -45,7 +47,7 @@ def test_shading_zero_solar_elevation(rectangular_geometry, square_field_layout)
 
 def test_no_shading(rectangular_geometry, square_field_layout):
     # Test shading calculation when there is no shading (high solar elevation)
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         square_field_layout
     shaded_fraction = shading.shaded_fraction(
@@ -65,7 +67,7 @@ def test_no_shading(rectangular_geometry, square_field_layout):
 
 def test_shading_below_horizon(rectangular_geometry, square_field_layout):
     # Test shading calculation when sun is below the horizon (elevation<0)
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         square_field_layout
     shaded_fraction = shading.shaded_fraction(
@@ -85,7 +87,7 @@ def test_shading_below_horizon(rectangular_geometry, square_field_layout):
 
 def test_shading_below_hill_horizon(rectangular_geometry, square_field_layout):
     # Test shading when sun is below horizon line caused by sloped surface
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         square_field_layout
     shaded_fraction = shading.shaded_fraction(
@@ -106,7 +108,7 @@ def test_shading_below_hill_horizon(rectangular_geometry, square_field_layout):
 def test_shading_max_shading_elevation(rectangular_geometry, square_field_layout):
     # Test that shaded_fraction is set to one when the solar elevation angle
     # is greater than the max_shading_elevation (even though shading may occur)
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
         square_field_layout
     shaded_fraction = shading.shaded_fraction(
@@ -123,3 +125,111 @@ def test_shading_max_shading_elevation(rectangular_geometry, square_field_layout
         max_shading_elevation=2,  # lower than true max angle for testing purposes
         plot=False)
     assert shaded_fraction == 0
+
+
+def test_return_geometries_negative_solar_elevation(
+        rectangular_geometry, active_geometry_split, square_field_layout):
+    # Test shaded_fraction function with return_geometries=True
+    # for the conditions (solar_elevation < 0)
+    collector_geometry, min_tracker_spacing = rectangular_geometry
+    X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
+        square_field_layout
+    shaded_fraction, geometries = shading.shaded_fraction(
+        solar_elevation=-10,  # Solar elevation less than 0
+        solar_azimuth=120,
+        total_collector_geometry=collector_geometry,
+        active_collector_geometry=active_geometry_split,
+        min_tracker_spacing=min_tracker_spacing,
+        tracker_distance=tracker_distance,
+        relative_azimuth=relative_azimuth,
+        relative_slope=relative_slope,
+        slope_azimuth=0,
+        slope_tilt=0,
+        # Also plots the geometry (ensures no errors are raised)
+        plot=True,
+        return_geometries=True)
+    assert geometries['unshaded_geometry'].equals(geometry.Polygon())
+    assert geometries['shading_geometries'].equals(geometry.Polygon())
+
+
+def test_return_geometries_below_horizon(
+        rectangular_geometry, active_geometry_split, square_field_layout):
+    # Test shaded_fraction function with return_geometries=True
+    # for the cases when solar elevation is below horizon (sloped ground)
+    collector_geometry, min_tracker_spacing = rectangular_geometry
+    X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
+        square_field_layout
+    shaded_fraction, geometries = shading.shaded_fraction(
+        solar_elevation=1,
+        solar_azimuth=180,
+        total_collector_geometry=collector_geometry,
+        active_collector_geometry=active_geometry_split,
+        min_tracker_spacing=min_tracker_spacing,
+        tracker_distance=tracker_distance,
+        relative_azimuth=relative_azimuth,
+        relative_slope=relative_slope,
+        slope_azimuth=0,
+        slope_tilt=5,
+        plot=False,
+        return_geometries=True)
+    assert geometries['unshaded_geometry'].equals(geometry.Polygon())
+    assert geometries['shading_geometries'].equals(geometry.Polygon())
+
+
+def test_return_geometries_above_max_shading_elevation(
+        rectangular_geometry, active_geometry_split, square_field_layout):
+    # Test shaded_fraction function with return_geometries=True
+    # for the case when the solar elevation angle is greater than the
+    # maximum_shading_elevation
+    collector_geometry, min_tracker_spacing = rectangular_geometry
+    X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
+        square_field_layout
+    shaded_fraction, geometries = shading.shaded_fraction(
+        solar_elevation=89,
+        solar_azimuth=180,
+        total_collector_geometry=collector_geometry,
+        active_collector_geometry=active_geometry_split,
+        min_tracker_spacing=min_tracker_spacing,
+        tracker_distance=tracker_distance,
+        relative_azimuth=relative_azimuth,
+        relative_slope=relative_slope,
+        slope_azimuth=0,
+        slope_tilt=0,
+        max_shading_elevation=50,  # force max_shading_elevation
+        plot=False,
+        return_geometries=True)
+    assert geometries['unshaded_geometry'].equals(active_geometry_split)
+    assert geometries['shading_geometries'].equals(geometry.Polygon())
+
+
+def test_return_geometries_normal_case(
+        rectangular_geometry, active_geometry_split, square_field_layout):
+    # Test shaded_fraction function with return_geometries=True
+    # for the cases when there is partly overlap between shading geometries and
+    # the active area
+    collector_geometry, min_tracker_spacing = rectangular_geometry
+    X, Y, Z, tracker_distance, relative_azimuth, relative_slope = \
+        square_field_layout
+    _, geometries = shading.shaded_fraction(
+        solar_elevation=5.2,
+        solar_azimuth=145,
+        total_collector_geometry=collector_geometry,
+        active_collector_geometry=active_geometry_split,
+        min_tracker_spacing=min_tracker_spacing,
+        tracker_distance=tracker_distance,
+        relative_azimuth=relative_azimuth,
+        relative_slope=relative_slope,
+        slope_azimuth=0,
+        slope_tilt=0,
+        plot=True,
+        return_geometries=True)
+    expected_active_geometry = geometry.MultiPolygon([
+            geometry.box(-1.9, -0.9, -0.1, -0.1),
+            # The shading areas overlap the bottom right panel of the collector
+            #  geometry.box(0.1, -0.9, 1.9, -0.1),
+            geometry.box(-1.9, 0.1, -0.1, 0.9),
+            geometry.box(0.1, 0.1, 1.9, 0.9)])
+    expected_shading_geometries = shapely.affinity.translate(
+        collector_geometry, 1.9646048635, -1.0098126057)
+    assert geometries['unshaded_geometry'].equals(expected_active_geometry)
+    assert geometries['shading_geometries'][0].almost_equals(expected_shading_geometries)

--- a/twoaxistracking/tests/test_shading.py
+++ b/twoaxistracking/tests/test_shading.py
@@ -233,3 +233,4 @@ def test_return_geometries_normal_case(
         collector_geometry, 1.9646048635, -1.0098126057)
     assert geometries['unshaded_geometry'].equals(expected_active_geometry)
     assert geometries['shading_geometries'][0].almost_equals(expected_shading_geometries)
+    assert len(geometries['shading_geometries']) == 1

--- a/twoaxistracking/tests/test_shading.py
+++ b/twoaxistracking/tests/test_shading.py
@@ -149,7 +149,7 @@ def test_return_geometries_negative_solar_elevation(
         plot=True,
         return_geometries=True)
     assert geometries['unshaded_geometry'].equals(geometry.Polygon())
-    assert geometries['shading_geometries'].equals(geometry.Polygon())
+    assert geometries['shading_geometries'] == []
 
 
 def test_return_geometries_below_horizon(
@@ -173,7 +173,7 @@ def test_return_geometries_below_horizon(
         plot=False,
         return_geometries=True)
     assert geometries['unshaded_geometry'].equals(geometry.Polygon())
-    assert geometries['shading_geometries'].equals(geometry.Polygon())
+    assert geometries['shading_geometries'] == []
 
 
 def test_return_geometries_above_max_shading_elevation(
@@ -199,7 +199,7 @@ def test_return_geometries_above_max_shading_elevation(
         plot=False,
         return_geometries=True)
     assert geometries['unshaded_geometry'].equals(active_geometry_split)
-    assert geometries['shading_geometries'].equals(geometry.Polygon())
+    assert geometries['shading_geometries'] == []
 
 
 def test_return_geometries_normal_case(

--- a/twoaxistracking/tests/test_trackerfield.py
+++ b/twoaxistracking/tests/test_trackerfield.py
@@ -6,7 +6,7 @@ import pytest
 
 def test_invalid_layout_type(rectangular_geometry):
     # Test if ValueError is raised when an incorrect layout_type is specified
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     with pytest.raises(ValueError, match="Layout type must be one of"):
         _ = trackerfield.TrackerField(
             total_collector_geometry=collector_geometry,
@@ -18,7 +18,7 @@ def test_invalid_layout_type(rectangular_geometry):
 
 def test_square_layout_type(rectangular_geometry):
     # Assert that layout field parameters are correctly set for the square layout
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -33,7 +33,7 @@ def test_square_layout_type(rectangular_geometry):
 
 def test_diagonal_layout_type(rectangular_geometry):
     # Assert that layout field parameters are correctly set for the diagonal layout
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -48,7 +48,7 @@ def test_diagonal_layout_type(rectangular_geometry):
 
 def test_hexagonal_n_s_layout_type(rectangular_geometry):
     # Assert that layout field parameters are correctly set for the diagonal layout
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -63,7 +63,7 @@ def test_hexagonal_n_s_layout_type(rectangular_geometry):
 
 def test_hexagonal_e_w_layout_type(rectangular_geometry):
     # Assert that layout field parameters are correctly set for the diagonal layout
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -78,7 +78,7 @@ def test_hexagonal_e_w_layout_type(rectangular_geometry):
 
 def test_unspecifed_layout_type(rectangular_geometry):
     # Test if ValueError is raised when one or more layout parameters are unspecified
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     with pytest.raises(ValueError, match="needs to be specified"):
         _ = trackerfield.TrackerField(
             total_collector_geometry=collector_geometry,
@@ -112,7 +112,7 @@ def test_calculation_of_shaded_fraction_list(rectangular_geometry, solar_positio
                                              expected_shaded_fraction):
     # Test if shaded fraction is calculated correct when solar elevation and
     # azimuth are lists
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -133,7 +133,7 @@ def test_calculation_of_shaded_fraction_series(
         rectangular_geometry, solar_position, expected_shaded_fraction, expected_datetime_index):
     # Test if shaded fraction is calculated correct when solar elevation and
     # azimuth are pandas Series
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -160,7 +160,7 @@ def test_calculation_of_shaded_fraction_array(rectangular_geometry, solar_positi
                                               expected_shaded_fraction):
     # Test if shaded fraction is calculated correct when solar elevation and
     # azimuth are numpy arrays
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -181,7 +181,7 @@ def test_calculation_of_shaded_fraction_float(rectangular_geometry):
     # azimuth are scalar
     # Also tests that no error is raised when total and active geometries are
     # identical.
-    collector_geometry, total_collector_area, min_tracker_spacing = rectangular_geometry
+    collector_geometry, min_tracker_spacing = rectangular_geometry
     field = trackerfield.TrackerField(
         total_collector_geometry=collector_geometry,
         active_collector_geometry=collector_geometry,
@@ -199,8 +199,8 @@ def test_calculation_of_shaded_fraction_float(rectangular_geometry):
 def test_total_collector_geometry_encloses_active_areas(rectangular_geometry, circular_geometry):
     # Test that ValueError is raised if the aperture collector geometry is not
     # completely enclosed by the total collector geometry
-    rectangular_collector, total_collector_area, min_tracker_spacing = rectangular_geometry
-    circular_collector, total_collector_area, min_tracker_spacing = circular_geometry
+    rectangular_collector, min_tracker_spacing = rectangular_geometry
+    circular_collector, min_tracker_spacing = circular_geometry
     with pytest.raises(ValueError, match="does not completely enclose"):
         _ = trackerfield.TrackerField(
             total_collector_geometry=rectangular_collector,


### PR DESCRIPTION
Closes #12

This PR adds a parameter called ``return_geometries`` to the ``shaded_fraction`` function. When this parameter is True, the function returns a tuple ``(shading_fraction, geometries)``, where ``geometries`` is a dictionary containing the unshaded area and the shading areas. When ``return_geometries`` is False, only the shading fraction is returned (default behavior).

The PR also removes the ``total_collector_area`` from the ``rectangular_geometry`` and ``circular_geometry`` in order to simplify the tests.