### PR TITLE
Fix shapely 2.0 ImportError

### DIFF
--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.4] - TBD
+
+### Changed
+- Removed Shapely instalation check and added specific import of the affinity module
+  to avoid import errors when using Shapely 2.0 (see PR#40).
+
+
 ## [0.2.3] - 2022-11-11
 It is now possible to export the unshaded area for further analysis. A GIF was added to the
 main landing page, and a reference to the MethodsX article was added.

--- a/twoaxistracking/__init__.py
+++ b/twoaxistracking/__init__.py
@@ -2,17 +2,3 @@
 from .layout import generate_field_layout  # noqa: F401
 from .shading import shaded_fraction  # noqa: F401
 from .trackerfield import TrackerField  # noqa: F401
-
-try:
-    from shapely.geos import lgeos  # noqa: F401
-except OSError as err:  # pragma: no cover
-    msg = (
-        "An error was encountered when importing the shapely package. "
-        "This often happens when a binary dependency is missing because "
-        "shapely was installed from PyPI using pip. Try reinstalling shapely "
-        "using conda with `conda install -c conda-forge shapely`, or "
-        "alternatively from Christoph Gohlke's website if you're on Windows: "
-        "https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely"
-     )
-    err.strerror += "; " + msg
-    raise err

--- a/twoaxistracking/shading.py
+++ b/twoaxistracking/shading.py
@@ -1,4 +1,4 @@
-import shapely
+from shapely import affinity
 from shapely import geometry
 import numpy as np
 from twoaxistracking import plotting
@@ -140,7 +140,7 @@ def shaded_fraction(solar_elevation, solar_azimuth,
         if np.sqrt(x**2+y**2) < min_tracker_spacing:
             # Project the geometry of the shading collector (total area) onto
             # the plane of the reference collector
-            shading_geometry = shapely.affinity.translate(total_collector_geometry, x, y)  # noqa: E501
+            shading_geometry = affinity.translate(total_collector_geometry, x, y)  # noqa: E501
             # Update the unshaded area based on overlapping shade
             unshaded_geometry = unshaded_geometry.difference(shading_geometry)
             if plot or return_geometries:

--- a/twoaxistracking/tests/test_shading.py
+++ b/twoaxistracking/tests/test_shading.py
@@ -232,5 +232,6 @@ def test_return_geometries_normal_case(
     expected_shading_geometries = shapely.affinity.translate(
         collector_geometry, 1.9646048635, -1.0098126057)
     assert geometries['unshaded_geometry'].equals(expected_active_geometry)
-    assert geometries['shading_geometries'][0].almost_equals(expected_shading_geometries)
+    assert geometries['shading_geometries'][0].equals_exact(
+        expected_shading_geometries, tolerance=0.00001)
     assert len(geometries['shading_geometries']) == 1


### PR DESCRIPTION
This PR fixes the import errors that occur when utilizing the newly released Shapely 2.0.

Closes #39

With Shapely 2.0, there are two import errors when running the twoaxistracking tests. The first occurs in this line:

     from shapely.geos import lgeos

which is used to check if Shapely and its dependencies were properly installed (in the __init__.py file).

The second import failure occurs when calling ``shapely.affinity.translate``. It seems that the affinity module is not imported automatically anymore when importing Shapely. To solve this, I added a specific import: ``from shapely import affinity``.