### PR TITLE
Fix twoaxistracking.__version__

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ and
 Contributions to the repository, e.g., bug fixes and improvements to speed up the code are more than welcome.
 
 ## License
-BSD 3-clause.
+[BSD 3-clause](LICENSE).

--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5]
+
+### Changed
+- ``twoaxistracking.__version__`` now correctly reports the version string instead
+  of raising ``AttributeError``. (:pull:`45`)
+
+
 ## [0.2.4] - 2023-01-05
 
 ### Changed

--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - ``twoaxistracking.__version__`` now correctly reports the version string instead
-  of raising ``AttributeError``. (:pull:`45`)
+  of raising ``AttributeError`` (see PR#45).
 
 
 ## [0.2.4] - 2023-01-05

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
 test =
     pytest
     pytest-cov
+    importlib-metadata; python_version < "3.8"
 doc =
     sphinx==4.4.0
     myst-nb==0.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,12 +25,12 @@ install_requires =
     matplotlib
     shapely
     pandas
+    importlib-metadata; python_version < "3.8"
 
 [options.extras_require]
 test =
     pytest
     pytest-cov
-    importlib-metadata; python_version < "3.8"
 doc =
     sphinx==4.4.0
     myst-nb==0.16.0

--- a/twoaxistracking/__init__.py
+++ b/twoaxistracking/__init__.py
@@ -1,3 +1,15 @@
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    # for python < 3.8 (remove when dropping 3.7 support)
+    from importlib_metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version(__package__)
+except PackageNotFoundError:
+    __version__ = "0+unknown"
+
+
 # Import of functions that should be accessible from the package top-level
 from .layout import generate_field_layout  # noqa: F401
 from .shading import shaded_fraction  # noqa: F401

--- a/twoaxistracking/__init__.py
+++ b/twoaxistracking/__init__.py
@@ -1,12 +1,12 @@
-try:
+try:  # pragma: no cover
     from importlib.metadata import PackageNotFoundError, version
-except ImportError:
+except ImportError:  # pragma: no cover
     # for python < 3.8 (remove when dropping 3.7 support)
     from importlib_metadata import PackageNotFoundError, version
 
-try:
+try:  # pragma: no cover
     __version__ = version(__package__)
-except PackageNotFoundError:
+except PackageNotFoundError:  # pragma: no cover
     __version__ = "0+unknown"
 
 

--- a/twoaxistracking/tests/test_twoaxistracking.py
+++ b/twoaxistracking/tests/test_twoaxistracking.py
@@ -1,0 +1,10 @@
+from pkg_resources import parse_version
+import twoaxistracking
+
+
+def test___version__():
+    # check that the version string is determined correctly.
+    # if the version string is messed up for some reason, it should be
+    # '0+unknown', which is not greater than '0.0.1'.
+    version = parse_version(twoaxistracking.__version__)
+    assert version > parse_version('0.0.1')


### PR DESCRIPTION
Currently, we aren't setting the __version__ attribute in __init__.py, which means twoaxistracking.__version__ raises AttributeError. This PR fixes that.

Issue and fix are similar to https://github.com/pvlib/pvanalytics/pull/181