### PR TITLE
Drop py 3.7, add py 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel other matrix jobs when one fails
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
    os: ubuntu-20.04
    tools:
-     python: "3.7"
+     python: "3.8"
 
 python:
    # only use the packages specified in setup.py

--- a/docs/source/whatsnew.md
+++ b/docs/source/whatsnew.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ``twoaxistracking.__version__`` now correctly reports the version string instead
   of raising ``AttributeError`` (see PR#45).
 
+### Testing
+- Remove python 3.7 and add python 3.12 to test matrix (see PR#48).
+
 
 ## [0.2.4] - 2023-01-05
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 
 [options]
 packages = twoaxistracking
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     numpy
     matplotlib

--- a/twoaxistracking/__init__.py
+++ b/twoaxistracking/__init__.py
@@ -1,8 +1,4 @@
-try:  # pragma: no cover
-    from importlib.metadata import PackageNotFoundError, version
-except ImportError:  # pragma: no cover
-    # for python < 3.8 (remove when dropping 3.7 support)
-    from importlib_metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, version
 
 try:  # pragma: no cover
     __version__ = version(__package__)


### PR DESCRIPTION
Support for python 3.7 is being dropped: https://github.com/pvlib/twoaxistracking/actions/runs/8954580349/job/24594386870

>   Error: The version '3.7' with architecture 'arm64' was not found for macOS 14.4.1.

This PR stops using python 3.7, and adds 3.12 to the test matrix.