### PR TITLE
Stop using deprecated/removed `pkg_resources`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
 test =
     pytest
     pytest-cov
+    packaging
 doc =
     sphinx==4.4.0
     myst-nb==0.16.0

--- a/twoaxistracking/tests/test_twoaxistracking.py
+++ b/twoaxistracking/tests/test_twoaxistracking.py
@@ -1,4 +1,4 @@
-from pkg_resources import parse_version
+from packaging.version import Version
 import twoaxistracking
 
 
@@ -6,5 +6,5 @@ def test___version__():
     # check that the version string is determined correctly.
     # if the version string is messed up for some reason, it should be
     # '0+unknown', which is not greater than '0.0.1'.
-    version = parse_version(twoaxistracking.__version__)
-    assert version > parse_version('0.0.1')
+    version = Version(twoaxistracking.__version__)
+    assert version > Version('0.0.1')


### PR DESCRIPTION
Same issue as:
- https://github.com/pvlib/pvlib-python/issues/1881

This caused recent tests to fail: https://github.com/pvlib/twoaxistracking/actions/runs/9085047522/job/24967428319