### PR TITLE
Remove PyPI token from publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,3 @@ jobs:
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This change in method was initiated by a comment raised [here](https://github.com/pvlib/twoaxistracking/actions/runs/12242790211).

![image](https://github.com/user-attachments/assets/6f49ab73-4960-442a-b02e-b3e8b70d9994)


I have added the pvlib/twoaxistracking/.github/workflows/publish.yml file as a trusted publisher.

![image](https://github.com/user-attachments/assets/28b2bcd1-2a2d-44d9-88fe-2bc357188ef5)

