### PR TITLE
Update permissions in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,5 @@
 name: Publish distributions to PyPI
 
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-
 # if this workflow is modified to be a generic CI workflow then
 # add an if statement to the publish step so it only runs on tags.
 on:
@@ -16,6 +12,9 @@ jobs:
     name: Build and publish distributions to PyPI
     if: github.repository == 'pvlib/twoaxistracking'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
     steps:
     # fetch all commits and tags so versioneer works
     - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 name: Publish distributions to PyPI
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 # if this workflow is modified to be a generic CI workflow then
 # add an if statement to the publish step so it only runs on tags.
 on:


### PR DESCRIPTION

The updates main in #60 was insufficient and resulted in [an error](https://github.com/pvlib/twoaxistracking/actions/runs/12279612393).


The solution is described [here](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings):

![image](https://github.com/user-attachments/assets/944ec132-a602-4e9d-83eb-08f06e034421)
