### PR TITLE
Add sphinx configuration path to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,7 @@
 version: 2
 
+sphinx:
+  configuration: docs/source/conf.py
 
 build:
    os: ubuntu-20.04


### PR DESCRIPTION
Fix the following error:

![image](https://github.com/user-attachments/assets/a225cd0a-a67a-41a6-b388-af9509572e92)
