### PR TITLE
Change author email format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,8 @@ where = ["src"]
 [project]
 name = "twoaxistracking"
 authors = [
-    {name = "Adam R. Jensen"},
+    {name = "Adam R. Jensen", email = "adam-r-j@hotmail.com"},
     {name = "Kevin S. Anderson"},
-    {email = "adam-r-j@hotmail.com"},
 ]
 description = "twoaxistracking is a python package for simulating two-axis tracking solar collectors, particularly self-shading."
 readme = "README.md"


### PR DESCRIPTION
Correctly specify my email with my name, instead of the email referring to both Kevin and I.

Inspired from https://github.com/AssessingSolar/solposx/pull/98